### PR TITLE
Typo - instead of Start Date it was Start End

### DIFF
--- a/inflation/templates/inflation/graph.html
+++ b/inflation/templates/inflation/graph.html
@@ -45,7 +45,7 @@
       <table class="striped">
         <thead>
           <tr>
-            <th>Start End</th>
+            <th>Start Date</th>
             <th>End Date</th>
             <th>Initial Amount</th>
             <th>Final Amount</th>


### PR DESCRIPTION
I believe it is supposed to say Start Date instead of Start End (typo). :) 